### PR TITLE
[codex] target Dependabot at dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
     open-pull-requests-limit: 5


### PR DESCRIPTION
## What changed
- Added `target-branch: dev` to Dependabot npm configuration.

## Why
- Dependabot reads its config from the default branch, so this needs to land on `main` for future updates to target `dev`.

## Validation
- `git diff --check`

## Notes
- No other files were changed.