### PR TITLE
[codex] group related Dependabot frontend updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,14 +7,10 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
     groups:
-      sveltejs:
+      frontend-core:
         patterns:
           - '@sveltejs/*'
-      vite:
-        patterns:
           - 'vite*'
-      vitest:
-        patterns:
           - 'vitest*'
       testing-library:
         patterns:


### PR DESCRIPTION
## What changed
- Grouped `@sveltejs/*`, `vite*`, and `vitest*` updates into a single Dependabot group.
- Kept `@testing-library/*` in its own group.

## Why
- Separate PRs for Vite and Svelte updates can conflict through peer dependencies and fail `npm ci` in CI.
- Grouping the related frontend packages ensures those coupled updates land together.

## Validation
- `git diff --check`

## Notes
- Existing open Dependabot PRs may need to be recreated after this lands so Dependabot regenerates them with the new grouping.