### PR TITLE
[codex] group tailwind and prettier dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
           - '@sveltejs/*'
           - 'vite*'
           - 'vitest*'
+          - '@tailwindcss/vite'
+      formatting:
+        patterns:
+          - 'prettier*'
+          - 'prettier-plugin-svelte*'
+          - 'prettier-plugin-tailwindcss*'
       testing-library:
         patterns:
           - '@testing-library/*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,14 +7,10 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
     groups:
-      sveltejs:
+      frontend-core:
         patterns:
           - '@sveltejs/*'
-      vite:
-        patterns:
           - 'vite*'
-      vitest:
-        patterns:
           - 'vitest*'
       testing-library:
         patterns:


### PR DESCRIPTION
## What changed
- Added `@tailwindcss/vite` to the frontend-core Dependabot group.
- Added a separate `formatting` group for `prettier`, `prettier-plugin-svelte`, and `prettier-plugin-tailwindcss`.

## Why
- The Vite/Tailwind updates are coupled through peer dependencies.
- The Prettier/Svelte formatting stack also needs to move together to avoid formatter breakage in CI.

## Validation
- `git diff --check`

## Notes
- This is a follow-up to the previously merged Dependabot grouping change.